### PR TITLE
Update compile script to support two instances

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -6,7 +6,7 @@ set -euo pipefail
 CLOUD_SQL_DOWNLOAD="https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/v2.14.0/cloud-sql-proxy.linux.amd64"
 
 log() {
-    echo "-----> $(printf '%s' "$@")" 1>&2
+	echo "-----> $(printf '%s' "$@")" 1>&2
 }
 
 log_extra() {
@@ -29,14 +29,29 @@ write_launch_script() {
 	local script_file="${1}"
 
 	touch "${script_file}"
-	cat <<EOF > "${script_file}"
-#!/bin/sh
+	cat <<EOF >"${script_file}"
 
-printf "%s" "\${CLOUD_SQL_CREDENTIALS}" | base64 -d > /app/google/credentials.json
-exec /app/google/bin/cloud_sql_proxy \\
-	--credentials-file=/app/google/credentials.json \\
-	--auto-iam-authn \\
-	\${CLOUD_SQL_INSTANCE} &
+	#!/bin/sh
+
+	# Decode service‐account JSON into a file
+	printf "%s" "${CLOUD_SQL_CREDENTIALS}" | base64 -d > /app/google/credentials.json
+
+	# --- start primary instance (no impersonation) ---
+	/app/google/bin/cloud_sql_proxy \
+		--credentials-file=/app/google/credentials.json \
+		--auto-iam-authn \
+		--instances="${CLOUD_SQL_INSTANCE}" &
+
+	# --- optionally start secondary instance (with impersonation) ---
+	if [ -n "${CLOUD_SQL_INSTANCE_2:-}" ]; then
+		/app/google/bin/cloud_sql_proxy \
+			--credentials-file=/app/google/credentials.json \
+			--auto-iam-authn \
+			--instances="${CLOUD_SQL_INSTANCE_2}" \
+			--impersonate-service-account="${CLOUD_SQL_IMPERSONATE_SERVICE_ACCOUNT}" &
+	fi
+
+	# (no exec here, this just backgrounds the proxies and lets the web process start normally)
 EOF
 	chmod +x "${script_file}"
 }

--- a/bin/compile
+++ b/bin/compile
@@ -45,6 +45,7 @@ write_launch_script() {
 	# --- optionally start secondary instance (with impersonation) ---
 	if [ -n "${CLOUD_SQL_INSTANCE_2:-}" ]; then
 		/app/google/bin/cloud_sql_proxy \
+			--run-connection-test \
 			--credentials-file=/app/google/credentials.json \
 			--auto-iam-authn \
 			--impersonate-service-account="${CLOUD_SQL_IMPERSONATE_SERVICE_ACCOUNT}" \

--- a/bin/compile
+++ b/bin/compile
@@ -48,7 +48,7 @@ write_launch_script() {
 			--run-connection-test \
 			--credentials-file=/app/google/credentials.json \
 			--auto-iam-authn \
-			--impersonate-service-account="${CLOUD_SQL_IMPERSONATE_SERVICE_ACCOUNT}" \
+			--impersonate-service-account="${CLOUD_SQL_2_IMPERSONATE_SERVICE_ACCOUNT}" \
 			${CLOUD_SQL_INSTANCE_2} &
 	fi
 

--- a/bin/compile
+++ b/bin/compile
@@ -40,15 +40,15 @@ write_launch_script() {
 	/app/google/bin/cloud_sql_proxy \
 		--credentials-file=/app/google/credentials.json \
 		--auto-iam-authn \
-		--instances="${CLOUD_SQL_INSTANCE}" &
+		${CLOUD_SQL_INSTANCE} &
 
 	# --- optionally start secondary instance (with impersonation) ---
 	if [ -n "${CLOUD_SQL_INSTANCE_2:-}" ]; then
 		/app/google/bin/cloud_sql_proxy \
 			--credentials-file=/app/google/credentials.json \
 			--auto-iam-authn \
-			--instances="${CLOUD_SQL_INSTANCE_2}" \
-			--impersonate-service-account="${CLOUD_SQL_IMPERSONATE_SERVICE_ACCOUNT}" &
+			--impersonate-service-account="${CLOUD_SQL_IMPERSONATE_SERVICE_ACCOUNT}" \
+			${CLOUD_SQL_INSTANCE_2} &
 	fi
 
 	# (no exec here, this just backgrounds the proxies and lets the web process start normally)

--- a/bin/compile
+++ b/bin/compile
@@ -29,7 +29,7 @@ write_launch_script() {
 	local script_file="${1}"
 
 	touch "${script_file}"
-	cat <<EOF >"${script_file}"
+	cat <<'EOF' >"${script_file}"
 
 	#!/bin/sh
 

--- a/bin/compile
+++ b/bin/compile
@@ -40,6 +40,7 @@ write_launch_script() {
 	/app/google/bin/cloud_sql_proxy \
 		--credentials-file=/app/google/credentials.json \
 		--auto-iam-authn \
+		--port=5432 \
 		${CLOUD_SQL_INSTANCE} &
 
 	# --- optionally start secondary instance (with impersonation) ---
@@ -48,6 +49,7 @@ write_launch_script() {
 			--run-connection-test \
 			--credentials-file=/app/google/credentials.json \
 			--auto-iam-authn \
+			--port=5433 \
 			--impersonate-service-account="${CLOUD_SQL_2_IMPERSONATE_SERVICE_ACCOUNT}" \
 			${CLOUD_SQL_INSTANCE_2} &
 	fi


### PR DESCRIPTION
Updated `write_launch_script`
- Conditionally starts a second instance if the `CLOUD_SQL_INSTANCE_2` env var is defined
- Script for starting second instance uses `--impersonate-service-account` flag
- Removed `exec` to launch two proxy processes in one script

Tested the updated build pack on the qa-automation-staging app, was able to build and deploy successfully (without `CLOUD_SQL_INSTANCE_2` and `CLOUD_SQL_IMPERSONATE_SERVICE_ACCOUNT` vars)